### PR TITLE
Add support for private repository in case of using -repo option

### DIFF
--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -73,7 +73,11 @@ class GittyLeak():
                 git('clone', 'https://github.com/{}/{}.git'.format(self.user, self.repo))
 
             except sh.ErrorReturnCode_128:
-                pass
+                try:
+                    # for Private Repository
+                    git('clone', 'git@github.com:{}/{}.git'.format(self.user, self.repo))
+                except sh.ErrorReturnCode_128:
+                    pass
 
         os.chdir(self.repo)
 


### PR DESCRIPTION
I made it possible to clone a private repository using the -repo option.