### PR TITLE
New options

### DIFF
--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -17,9 +17,6 @@ class GittyLeak():
 
         self.revision_file_regex = '([a-z0-9]{40}):([^:]+):'
 
-        assignment = "(\\b|[ ._-])({})[ '\"]*(=|:)[ '\"]*([^'\" ]+)"
-        self.assignment_pattern = assignment.format('|'.join(self.keywords))
-
         self.excluded_value_chars = [
             '.', '[', 'none', 'true', 'false', 'null',
             'default', 'example', 'username', 'email', 'password'
@@ -28,6 +25,7 @@ class GittyLeak():
         self.min_value_length = 4
 
         self.excluding = None
+        self.key_prefix = True
         self.revision_list = []
         self.search_only_head = False
         self.user = None
@@ -45,6 +43,10 @@ class GittyLeak():
 
         if kwargs is not None:
             self.apply_init_args(kwargs)
+
+        prefix_pattern = "\\b|[ ._-]" if self.key_prefix else ".*"
+
+        self.assignment_pattern = f"({prefix_pattern})({'|'.join(self.keywords)})[ '\"]*(=|:)[ '\"]*([^'\" ]+)"
 
     def apply_init_args(self, kwargs):
         for k, v in kwargs.items():
@@ -222,6 +224,8 @@ def get_args_parser():
                    help='flag: If you want to be specific about case matching.')
     p.add_argument('--excluding', '-e', nargs='+',
                    help='List of words that are ignored occurring as value.')
+    p.add_argument('--no-key-prefix', '-p', action='store_false', dest='key_prefix',
+                   help='Don\'t limit keywords to start of line or prefixing with one of [ ._-]')
     p.add_argument('--verbose', '-v', action='store_true',
                    help='If flag given, print verbose matches.')
     p.add_argument('--no-banner', '-b', action='store_true',

--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -226,37 +226,53 @@ def colorize(val, code):
 def get_args_parser():
     p = argparse.ArgumentParser(
         description='Discover where your sensitive data has been leaked.')
-    p.add_argument('-user', '-u',
+
+    p.add_argument('-u', '-user',
                    help='Provide a github username, only if also -repo')
-    p.add_argument('-repo', '-r',
+
+    p.add_argument('-r', '-repo',
                    help='Provide a github repo, only if also -user')
-    p.add_argument('-link', '-l',
+
+    p.add_argument('-l', '-link',
                    help='Provide a link to clone')
-    p.add_argument('-delete', '-d', action='store_true',
+
+    p.add_argument('-d', '-delete', action='store_true',
                    help='If cloned, remove the repo afterwards.')
-    p.add_argument('--find-anything', '-a', action='store_true',
+
+    p.add_argument('-a', '--find-anything', action='store_true',
                    help='flag: If you want to find anything remotely suspicious.')
-    p.add_argument('--search-only-head', '-o', action='store_true',
+
+    p.add_argument('-o', '--search-only-head', action='store_true',
                    help='If flag given, only search HEAD not all commit history.')
-    p.add_argument('--case-sensitive', '-c', action='store_true',
+
+    p.add_argument('-c', '--case-sensitive', action='store_true',
                    help='flag: If you want to be specific about case matching.')
-    p.add_argument('--excluding', '-e', nargs='+',
+
+    p.add_argument('-e', '--excluding', nargs='+',
                    help='List of words that are ignored occurring as value.')
-    p.add_argument('--add-keys', '-k', nargs='+',
+
+    p.add_argument('-k', '--add-keys', nargs='+',
                    help='List of words that are added as keys.')
-    p.add_argument('--ignore-keys', '-i', nargs='+',
+
+    p.add_argument('-i', '--ignore-keys', nargs='+',
                    help='List of words that are ignored occurring as  default key. Use \'*\' for all.')
-    p.add_argument('--list-keys', '-L', action='store_true',
+
+    p.add_argument('-L', '--list-keys', action='store_true',
                    help='Display search keys, then exit')
-    p.add_argument('--no-key-prefix', '-p', action='store_false', dest='key_prefix',
+
+    p.add_argument('-p', '--no-key-prefix', action='store_false', dest='key_prefix',
                    help='Don\'t limit keywords to start of line or prefixing with one of [ ._-]')
-    p.add_argument('--line-numbers', '-n', action='store_true',
+
+    p.add_argument('-n', '--line-numbers', action='store_true',
                    help='Show line numbers in matching files')
-    p.add_argument('--verbose', '-v', action='store_true',
+
+    p.add_argument('-v', '--verbose', action='store_true',
                    help='If flag given, print verbose matches.')
-    p.add_argument('--no-banner', '-b', action='store_true',
+
+    p.add_argument('-b', '--no-banner', action='store_true',
                    help='Omit the banner at the start of a print statement')
-    p.add_argument('--no-fancy-color', '-f', action='store_false', dest="fancy_color",
+
+    p.add_argument('-f', '--no-fancy-color', action='store_false', dest="fancy_color",
                    help='Do not colorize output')
     return p
 

--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -40,7 +40,7 @@ class GittyLeak():
         self.delete = None
         self.matched_items = []
         self.verbose = None
-        self.no_fancy_color = None
+        self.fancy_color = None
         self.BANNER_WIDTH = 80
 
         if kwargs is not None:
@@ -161,7 +161,7 @@ class GittyLeak():
         for k, v in self.matched_items.items():
             for appear in set([x[0] for x in v]):
                 # 32 is green, 31 is red
-                if not self.no_fancy_color:
+                if self.fancy_color:
                     fname = colorize(k[0], '36')
                     appear = appear.replace(k[1], colorize(k[1], '33'))
                     appear = appear.replace(k[2], colorize(k[2], '31'))
@@ -226,7 +226,7 @@ def get_args_parser():
                    help='If flag given, print verbose matches.')
     p.add_argument('--no-banner', '-b', action='store_true',
                    help='Omit the banner at the start of a print statement')
-    p.add_argument('--no-fancy-color', '-f', action='store_true',
+    p.add_argument('--no-fancy-color', '-f', action='store_false', dest="fancy_color",
                    help='Do not colorize output')
     return p
 

--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -29,6 +29,7 @@ class GittyLeak():
         self.ignore_keys = None
         self.list_keys = False
         self.key_prefix = True
+        self.line_numbers = False
         self.revision_list = []
         self.search_only_head = False
         self.user = None
@@ -104,7 +105,12 @@ class GittyLeak():
 
     def get_git_matches(self, revision):
         try:
-            return str(git('grep', '-i', '-e', '"({})"'.format(r'\|'.join(self.keywords)),
+            flags = "-i"
+
+            if self.line_numbers:
+                flags += "n"
+
+            return str(git('grep', flags, '-e', '"({})"'.format(r'\|'.join(self.keywords)),
                            revision, _tty_out=False))
         # return subprocess.check_output('git grep -i -e
         # "(api\\|key\\|username\\|user\\|pw\\|password\\|pass\\|email\\|mail)" --
@@ -244,6 +250,8 @@ def get_args_parser():
                    help='Display search keys, then exit')
     p.add_argument('--no-key-prefix', '-p', action='store_false', dest='key_prefix',
                    help='Don\'t limit keywords to start of line or prefixing with one of [ ._-]')
+    p.add_argument('--line-numbers', '-n', action='store_true',
+                   help='Show line numbers in matching files')
     p.add_argument('--verbose', '-v', action='store_true',
                    help='If flag given, print verbose matches.')
     p.add_argument('--no-banner', '-b', action='store_true',

--- a/gittyleaks/gittyleaks.py
+++ b/gittyleaks/gittyleaks.py
@@ -25,6 +25,9 @@ class GittyLeak():
         self.min_value_length = 4
 
         self.excluding = None
+        self.add_keys = None
+        self.ignore_keys = None
+        self.list_keys = False
         self.key_prefix = True
         self.revision_list = []
         self.search_only_head = False
@@ -57,6 +60,15 @@ class GittyLeak():
 
         if self.excluding is not None:
             self.excluded_value_chars.extend(self.excluding)
+
+        if self.ignore_keys is not None:
+            if self.ignore_keys == ["*"]:
+                self.keywords = []
+            else:
+                self.keywords = list(filter(lambda key : key not in self.ignore_keys, self.keywords))
+
+        if self.add_keys is not None:
+            self.keywords += self.add_keys
 
         if not self.case_sensitive:
             self.excluded_value_chars = [x.lower() for x in self.excluded_value_chars]
@@ -224,6 +236,12 @@ def get_args_parser():
                    help='flag: If you want to be specific about case matching.')
     p.add_argument('--excluding', '-e', nargs='+',
                    help='List of words that are ignored occurring as value.')
+    p.add_argument('--add-keys', '-k', nargs='+',
+                   help='List of words that are added as keys.')
+    p.add_argument('--ignore-keys', '-i', nargs='+',
+                   help='List of words that are ignored occurring as  default key. Use \'*\' for all.')
+    p.add_argument('--list-keys', '-L', action='store_true',
+                   help='Display search keys, then exit')
     p.add_argument('--no-key-prefix', '-p', action='store_false', dest='key_prefix',
                    help='Don\'t limit keywords to start of line or prefixing with one of [ ._-]')
     p.add_argument('--verbose', '-v', action='store_true',
@@ -239,6 +257,11 @@ def main():
     """ This is the function that is run from commandline with `gittyleaks` """
     args = get_args_parser().parse_args()
     gl = GittyLeak(args.__dict__)
+
+    if gl.list_keys:
+        print(f"keys : {gl.keywords}")
+        return
+
     try:
         gl.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
Thank you for gittyleaks, it's been useful here. 

I've added a some changes which others may / may not find a use for too. More info in each commit message.

The three main commits add commandline options for:

* Displaying/manipulating the default search terms
* Displaying line numbers with matches
* Allowing terms to match without either beginning a line or follwoing one of [ ._-]

The other two commits are code tidies.